### PR TITLE
Add proof explorer

### DIFF
--- a/src/components/Proof.svelte
+++ b/src/components/Proof.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import type { ProofNode, ProofTree } from '$lib/proof-tree'
+
+  import { getDelegates } from '$lib/proof-tree'
+  import NodeGroup from '$components/proof/NodeGroup.svelte'
+
+  export let proofTree: ProofTree
+
+  let selected: ProofNode[] = null
+  let proofs: ProofNode[] = []
+  let delegates: ProofNode[] = []
+
+  $: {
+    selected = [proofTree]
+    proofs = proofTree.proofs
+    delegates = getDelegates(proofTree, [])
+  }
+</script>
+
+{#if selected !== null}
+  <div class="node-group-container">
+    {#if delegates.length > 0}
+      <NodeGroup type="delegate" bind:nodes={delegates} on:selectproof />
+    {/if}
+    <NodeGroup type="selected" bind:nodes={selected} on:selectproof />
+    {#if proofs.length > 0}
+      <NodeGroup type="proof" bind:nodes={proofs} on:selectproof />
+    {/if}
+  </div>
+{/if}
+
+<style>
+  .node-group-container {
+    display: flex;
+    column-gap: 8px;
+  }
+</style>

--- a/src/components/proof/Node.svelte
+++ b/src/components/proof/Node.svelte
@@ -1,0 +1,117 @@
+<script lang="ts">
+  import { Button } from 'carbon-components-svelte'
+  import { createEventDispatcher } from 'svelte'
+
+  import type { ProofNode } from '$lib/proof-tree'
+  import NodeHint from './NodeHint.svelte'
+
+  export let node: ProofNode
+  export let type: 'selected' | 'proof' | 'delegate'
+  export let label: string
+
+  let isValid: boolean = true
+  let buttonProps: { class: string }
+
+  const dispatch = createEventDispatcher()
+
+  const select = () => {
+    dispatch('selectproof', { node })
+  }
+
+  const kind =
+    type === 'selected'
+      ? 'primary'
+      : type === 'proof'
+      ? 'secondary'
+      : 'tertiary'
+
+  $: isValid =
+    node.ucan !== null &&
+    node.validation !== null &&
+    node.validation.notValidYet === false &&
+    node.validation.active === true &&
+    node.validation.valid === true &&
+    node.validation.validIssuer === true &&
+    node.validation.validProofs === true
+
+  $: buttonProps = {
+    class: [
+      'button',
+      'bx--btn',
+      `bx--btn--${kind}`,
+      !isValid && 'bx--btn--warning',
+      node.ucan === null && 'bx--btn--undecodable'
+    ]
+      .filter(Boolean)
+      .join(' ')
+  }
+</script>
+
+<NodeHint direction="top" align="start">
+  <Button as>
+    <div {...buttonProps} on:click={select}>
+      <span class="absolute-label">{node.label}</span>
+      <span>{label}</span>
+    </div>
+  </Button>
+  <div slot="tooltip" class="tooltip">
+    <div class="tooltip-row">
+      <span>Valid</span>
+      <span>{isValid}</span>
+    </div>
+    <div class="tooltip-row">
+      <span>Issuer</span>
+      <span>{node.ucan ? node.ucan.payload.iss : 'Cannot decode token'}</span>
+    </div>
+    <div class="tooltip-row">
+      <span>Audience</span>
+      <span>{node.ucan ? node.ucan.payload.aud : 'Cannot decode token'}</span>
+    </div>
+  </div>
+</NodeHint>
+
+<style>
+  .button {
+    display: grid;
+    grid-template-columns: 1fr 5fr;
+    grid-gap: 8px;
+    padding: calc(0.875rem - 3px) 15px calc(0.875rem - 3px) 15px;
+  }
+
+  .bx--btn--warning::after {
+    position: absolute;
+    top: 0;
+    right: 0;
+    width: 0;
+    height: 0;
+    border-style: solid;
+    border-width: 0 12px 12px 0;
+    border-color: transparent #f1c21b transparent transparent;
+    content: '';
+  }
+
+  .bx--btn--undecodable::after {
+    filter: opacity(60%) saturate(300%);
+  }
+
+  .absolute-label {
+    font-size: 12px;
+    border: 1px solid #eee;
+    padding: 0 3px 0 3px;
+  }
+
+  .bx--btn--tertiary .absolute-label {
+    border: 1px solid #4385fe;
+  }
+
+  .tooltip {
+    display: grid;
+    row-gap: 12px;
+  }
+
+  .tooltip-row {
+    display: grid;
+    grid-template-columns: 1fr 3fr;
+    column-gap: 15px;
+  }
+</style>

--- a/src/components/proof/NodeGroup.svelte
+++ b/src/components/proof/NodeGroup.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import type { ProofNode } from '$lib/proof-tree'
+
+  import Node from '$components/proof/Node.svelte'
+
+  export let nodes: ProofNode[] = []
+  export let type: 'selected' | 'proof' | 'delegate'
+</script>
+
+<div class="node-group">
+  {#each nodes as node, index}
+    {#if type === 'delegate'}
+      <Node
+        {node}
+        {type}
+        label={`Delegate ${nodes.length - index}`}
+        on:selectproof
+      />
+    {:else if type === 'selected'}
+      <Node {node} {type} label="Selected" on:selectproof />
+    {:else}
+      <Node {node} {type} label={`Proof ${index + 1}`} on:selectproof />
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .node-group {
+    display: inline-flex;
+    flex-direction: row;
+    column-gap: 2px;
+  }
+</style>

--- a/src/components/proof/NodeHint.svelte
+++ b/src/components/proof/NodeHint.svelte
@@ -1,0 +1,78 @@
+<script>
+  /** Specify the tooltip text */
+  export let tooltipText = ''
+
+  /**
+   * Set the alignment of the tooltip relative to the icon
+   * @type {'start' | 'center' | 'end'}
+   */
+  export let align = 'center'
+
+  /**
+   * Set the direction of the tooltip relative to the icon
+   * @type {'top' | 'bottom'}
+   */
+  export let direction = 'bottom'
+
+  /** Set an id for the tooltip div element */
+  export let id = 'ccs-' + Math.random().toString(36)
+
+  /** Obtain a reference to the button HTML element */
+  export let ref = null
+
+  let visible = false
+
+  function hide() {
+    visible = false
+  }
+
+  function show() {
+    visible = true
+  }
+</script>
+
+<svelte:window
+  on:keydown={({ key }) => {
+    if (key === 'Escape') hide()
+  }}
+/>
+
+<span
+  class:bx--tooltip--definition={true}
+  class:bx--tooltip--a11y={true}
+  {...$$restProps}
+  on:mouseenter={show}
+  on:mouseleave={hide}
+>
+  <button
+    bind:this={ref}
+    aria-describedby={id}
+    class:bx--tooltip--a11y={true}
+    class:bx--tooltip__trigger={true}
+    class:bx--tooltip__trigger--definition={true}
+    class:bx--tooltip--hidden={!visible}
+    class:bx--tooltip--visible={visible}
+    class:bx--tooltip--top={direction === 'top'}
+    class:bx--tooltip--bottom={direction === 'bottom'}
+    class:bx--tooltip--align-start={align === 'start'}
+    class:bx--tooltip--align-center={align === 'center'}
+    class:bx--tooltip--align-end={align === 'end'}
+    on:click
+    on:mouseover
+    on:mouseenter
+    on:mouseleave
+    on:focus
+    on:focus={show}
+    on:blur={hide}
+  >
+    <slot />
+  </button>
+  <div
+    role="tooltip"
+    {id}
+    class:bx--assistive-text={true}
+    style="max-width:20rem"
+  >
+    <slot name="tooltip">{tooltipText}</slot>
+  </div>
+</span>

--- a/src/lib/proof-tree.ts
+++ b/src/lib/proof-tree.ts
@@ -1,0 +1,86 @@
+import type { Ucan } from 'ucans'
+import type { Validation } from '$lib/ucan'
+
+import { decode, validate } from '$lib/ucan'
+
+export type ProofTree = ProofNode | null
+
+export type ProofNode = {
+  label: string
+  token: string
+  ucan: Ucan
+  validation: Validation
+  proofs: ProofTree[]
+  parent: ProofTree
+}
+
+export const createProofTree = async (token: string): Promise<ProofTree> => {
+  const proofTree = await createTree(token, null)
+  const labeledProofTree = labelTree(proofTree, 0)
+
+  return labeledProofTree
+}
+
+const createTree = async (token: string, parent: ProofTree): Promise<ProofTree> => {
+  const ucan = decode(token)
+
+  if (ucan !== null) {
+    const validation: Validation = await validate(ucan)
+
+    const tree: ProofTree = {
+      label: '',
+      token,
+      ucan,
+      validation,
+      parent,
+      proofs: []
+    }
+
+    const promisedProofs = ucan.payload.prf.map(proof => createTree(proof, tree))
+    tree.proofs = await Promise.all(promisedProofs)
+
+    return tree
+  } else {
+    const tree: ProofTree = {
+      label: '',
+      token,
+      ucan: null,
+      validation: null,
+      parent,
+      proofs: []
+    }
+
+    return tree
+  }
+}
+
+const labelTree = (root: ProofNode, index: number): ProofTree => {
+  const queue = [root]
+
+  while (queue.length > 0) {
+    const currentNode = queue.shift()
+    currentNode.label = label(index)
+    index = index + 1
+
+    currentNode.proofs.forEach(proof => {
+      queue.push(proof)
+    })
+  }
+
+  return root
+}
+
+const label = (index: number): string => {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+  const chars = Math.ceil((index + 1) / 26)
+
+  return alphabet[index].repeat(chars)
+}
+
+export const getDelegates = (node: ProofTree, chain: ProofTree[]): ProofNode[] => {
+  if (node.parent !== null) {
+    chain = [ node.parent, ...chain ]
+    return getDelegates(node.parent, chain)
+  }
+  return chain 
+}

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -20,16 +20,20 @@
 
   import type { Ucan } from 'ucans'
   import type { Validation } from '$lib/ucan'
+  import type { ProofTree } from '$lib/proof-tree'
 
   import * as explantion from '$lib/explanation'
   import * as ucan from '$lib/ucan'
   import { formatDate, formatJson } from '$lib/utils'
+  import { createProofTree } from '$lib/proof-tree'
+  import Proof from '$components/Proof.svelte'
 
   let setDevice = () => {}
 
   let encodedUcan: string = ''
   let decodedUcan: Ucan | null = null
   let validation: Validation | null = null
+  let proofTree: ProofTree = null
   let isMobileDevice: boolean
 
   onMount(() => {
@@ -44,29 +48,37 @@
     setDevice()
   })
 
-  const decode = event => {
+  const showUcan = event => {
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
     encodedUcan = event.target.value.trim()
     decodedUcan = ucan.decode(encodedUcan)
+
+    createProofTree(encodedUcan)
+      .then(val => {
+        proofTree = val
+      })
+      .catch(err => {
+        console.log('Could not create proof tree: ', err)
+      })
   }
 
   const showExample = () => {
     encodedUcan =
-      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuNy4wIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWtzcFNaVlNBM0tWVXZWazZvNVpWTmJ6ZWNqUkNETmZ0TlJMN3M3REtHZkhGbiIsImF0dCI6W3sid25mcyI6ImRlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyIsImNhcCI6Ik9WRVJXUklURSJ9XSwiZXhwIjo5MjU2OTM5NTA1LCJpc3MiOiJkaWQ6a2V5Ono2TWtoSHN1Y012c05ISDNvU3E0YW15a2RodVY2QjVBR1ZaSnpDaG5UOE1KTk03WiIsIm5iZiI6MTYzOTAwMTY0MCwicHJmIjpbImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJa3BYVkNJc0luVmpkaUk2SWpBdU55NHdJbjAuZXlKaGRXUWlPaUprYVdRNmEyVjVPbm8yVFd0b1NITjFZMDEyYzA1SVNETnZVM0UwWVcxNWEyUm9kVlkyUWpWQlIxWmFTbnBEYUc1VU9FMUtUazAzV2lJc0ltRjBkQ0k2VzNzaWQyNW1jeUk2SW1SbGJXOTFjMlZ5TG1acGMzTnBiMjR1Ym1GdFpTOXdkV0pzYVdNdmNHaHZkRzl6THlJc0ltTmhjQ0k2SWs5V1JWSlhVa2xVUlNKOVhTd2laWGh3SWpvNU1qVTJPVE01TlRBMUxDSnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdG5ObEo0YVV4b1duQlJibFJoUkhJNGFUWmlXV053YVU1dVlrNDFabGRZUjNneVNuQlVNMnBxVXpKR1dpSXNJbTVpWmlJNk1UWXpPVEF3TVRZME1Dd2ljSEptSWpwYlhYMC5idFBVQ2w2cVg2WTMtdzE5NE9sZ09vSHN0TmFkNkszS2N1QnhJd0RUOUZfSnU5aDBwOUJyWXNwNHlORFFaYVFycXlWUV9lbjR1ajBnb0JXTExZWk5EUSJdfQ.jzRbm6D7FpKpouT7OrRrl_5-95vgZALyq-Vmy7LCYTx0OmxW8C6Ld2lSq1tIviotaIQ3hxVACdx-Q2yJ3i4GBA'
-    decode({ target: { value: encodedUcan } })
+      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuNy4wIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWt2WGZQVXY4Ynh0c1ZRaUdvN050azRxS0pOY2dLMml0NTJwYzczdGVVcFJMVCIsImF0dCI6W3sid25mcyI6ImRlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyIsImNhcCI6Ik9WRVJXUklURSJ9LHsid25mcyI6ImRlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvbm90ZXMvIiwiY2FwIjoiT1ZFUldSSVRFIn1dLCJleHAiOjkyNTY5Mzk1MDUsImlzcyI6ImRpZDprZXk6ejZNa3NYUUJmTDhvd3p0VENKVG03aE5SZjZiMThZeFhQcDNpNjZvSkhtOEwzWUdKIiwibmJmIjoxNjM5NjA4MjkzLCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1Tnk0d0luMC5leUpoZFdRaU9pSmthV1E2YTJWNU9ubzJUV3R6V0ZGQ1prdzRiM2Q2ZEZSRFNsUnROMmhPVW1ZMllqRTRXWGhZVUhBemFUWTJiMHBJYlRoTU0xbEhTaUlzSW1GMGRDSTZXM3NpZDI1bWN5STZJbVJsYlc5MWMyVnlMbVpwYzNOcGIyNHVibUZ0WlM5d2RXSnNhV012Y0dodmRHOXpMeUlzSW1OaGNDSTZJazlXUlZKWFVrbFVSU0o5WFN3aVpYaHdJam81TWpVMk9UTTVOVEExTENKcGMzTWlPaUprYVdRNmEyVjVPbm8yVFd0d05VVnplamx6TWsxSWMzRlpka3h2WTJONVNIZFlOVk5sZVZwTGNIRTNPVWQwTkRWbVJrZEZXbEk1T1NJc0ltNWlaaUk2TVRZek9UWXdPREk1TXl3aWNISm1JanBiWFgwLjRUTmh1SFJyUEc5YUhvODY5SFhsc05LOF9GbWxTaFE1R3pHNGl0TjJOS2steUtUYkFNb0Z3VHVwdEcwWEZnTkl2SHVsUHBsVnpaWURWRGV4bzc2a0F3IiwiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1Tnk0d0luMC5leUpoZFdRaU9pSmthV1E2YTJWNU9ubzJUV3R6V0ZGQ1prdzRiM2Q2ZEZSRFNsUnROMmhPVW1ZMllqRTRXWGhZVUhBemFUWTJiMHBJYlRoTU0xbEhTaUlzSW1GMGRDSTZXM3NpZDI1bWN5STZJbVJsYlc5MWMyVnlMbVpwYzNOcGIyNHVibUZ0WlM5d2RXSnNhV012Ym05MFpYTXZJaXdpWTJGd0lqb2lUMVpGVWxkU1NWUkZJbjFkTENKbGVIQWlPamt5TlRZNU16azFNRFVzSW1semN5STZJbVJwWkRwclpYazZlalpOYTNBMVJYTjZPWE15VFVoemNWbDJURzlqWTNsSWQxZzFVMlY1V2t0d2NUYzVSM1EwTldaR1IwVmFVams1SWl3aWJtSm1Jam94TmpNNU5qQTRNamt6TENKd2NtWWlPbHRkZlEuTWdZYXJMcXk3Um1RMUFJcnFZTDZjRnk5ejdhNVdJQVUtLVRZQVJQU2dpck9Tc3p2YXIzX0ROcjI1cmJQcmV0SGJuVDBtTVZLeW9hUVhydVI3S2JyQmciXX0.kwRdqPN74pkcpXGgdk7Z7FW3M1mRRYaDE5ZgkG6srAuu6V6mvMVRdBLnD5CWid-X4tDIKpliVjlCSLTntB4pCw'
+    showUcan({ target: { value: encodedUcan } })
   }
 
   const showInvalidExample = () => {
     encodedUcan =
-      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuNy4wIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWttRDMxeG5aaFNnY3hwc2pxWmhSanRLMWJqUExxdVU1ZVNITTV6U3NIdzFtNSIsImF0dCI6W3sid25mcyI6ImRlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyIsImNhcCI6Ik9WRVJXUklURSJ9XSwiZXhwIjoxNjM5MDAxMTcyLCJpc3MiOiJkaWQ6a2V5Ono2TWtuVWppNUNTUVNLR1JEZkRSSjl3MWJoaUpLQ3dyTWFiczdkZUhjcW5CU1dIZyIsIm5iZiI6MTYzOTAwMTExMiwicHJmIjpbImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJa3BYVkNJc0luVmpkaUk2SWpBdU55NHdJbjAuZXlKaGRXUWlPaUprYVdRNmEyVjVPbm8yVFd0dFJETXhlRzVhYUZOblkzaHdjMnB4V21oU2FuUkxNV0pxVUV4eGRWVTFaVk5JVFRWNlUzTklkekZ0TlNJc0ltRjBkQ0k2VzNzaWQyNW1jeUk2SW1SbGJXOTFjMlZ5TG1acGMzTnBiMjR1Ym1GdFpTOXdkV0pzYVdNdmNHaHZkRzl6THlJc0ltTmhjQ0k2SWs5V1JWSlhVa2xVUlNKOVhTd2laWGh3SWpveE5qTTVNREF4TVRjeUxDSnBjM01pT2lKa2FXUTZhMlY1T25vMlRXdHFaR1pSVFhjelkxTmlVRWRpWmxFMU1uSmhSRVkxZEVSM1VYWkxlbGh4YjJKRlJWQkRiVzlxV2pFM2RpSXNJbTVpWmlJNk1UWXpPVEF3TVRFeE1pd2ljSEptSWpwYlhYMC5QSmY2OGhZbDBfSmFvTUNUa05JYXZUd3J4Qjk4aFJGb05oOGpXSDhyVzdyUUZtaGdlM1k0a2JYbnAwZ0xQR05CRlp6UWZnYmRVSGFTNnhaclRmQmRBZz09Il19.PJf68hYl0_JaoMCTkNIavTwrxB98hRFoNh8jWH8rW7rQFmhge3Y4kbXnp0gLPGNBFZzQfgbdUHaS6xZrTfBdAg=='
-    decode({ target: { value: encodedUcan } })
+      'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuNy4wIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWt1UzNKdlFpdEhxbTJTZzJCRHMyb3hGeVc0em1tQzRnOGtKRXBBTWVyVnp0RyIsImF0dCI6W3sid25mcyI6ImRlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyIsImNhcCI6Ik9WRVJXUklURSJ9LHsid25mcyI6ImRlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvbm90ZXMvIiwiY2FwIjoiT1ZFUldSSVRFIn1dLCJleHAiOjkyNTY5Mzk1MDUsImlzcyI6ImRpZDprZXk6ejZNa2tpQ0piRVVSYU1LSHJ0a0VnYmlVQWN4cDNzZ3RRMU1lV3BrZ2NtUWFWZVc2IiwibmJmIjoxNjM5NjA4ODc4LCJwcmYiOlsiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1Tnk0d0luMC5leUpoZFdRaU9pSmthV1E2YTJWNU9ubzJUV3RyYVVOS1lrVlZVbUZOUzBoeWRHdEZaMkpwVlVGamVIQXpjMmQwVVRGTlpWZHdhMmRqYlZGaFZtVlhOaUlzSW1GMGRDSTZXM3NpZDI1bWN5STZJbVJsYlc5MWMyVnlMbVpwYzNOcGIyNHVibUZ0WlM5d2RXSnNhV012Y0dodmRHOXpMeUlzSW1OaGNDSTZJazlXUlZKWFVrbFVSU0o5WFN3aVpYaHdJam81TWpVMk9UTTVOVEExTENKcGMzTWlPaUprYVdRNmEyVjVPbm8yVFd0b1ltRTNObHB6YTFkclJVZEdhalptVkUxaWRGUk9XSFp6UVRRek5YZFVlVzVsTVZsMmFFTTRhMFJ5TnlJc0ltNWlaaUk2TVRZek9UWXdPRGczT0N3aWNISm1JanBiWFgwLlBKZjY4aFlsMF9KYW9NQ1RrTklhdlR3cnhCOThoUkZvTmg4aldIOHJXN3JRRm1oZ2UzWTRrYlhucDBnTFBHTkJGWnpRZmdiZFVIYVM2eFpyVGZCZEFnPT0iLCJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVOeTR3SW4wLmV5SmhkV1FpT2lKa2FXUTZhMlY1T25vMlRXdDJjVTUyUXpaVGRXTXlhbkZ5Y3pGRWEzaElVVlV4U205VlhabFVuRTRZMk5uUldRMFJtcHFWblphSWl3aWJtSm1Jam94TmpNNU5qQTROemt6TENKd2NtWWlPbHRkZlEueVZZdzhjdFNER2IybHhlU0w5MDdPbW5NWVVOV3lDYjlUZUZnR2xnTmIwOXR2aFRBZE00NnpKSUxtcC0tY2t0c3lIWmZUbkItVVVRRTJRTlpYNVp1QUEiLCJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVOeTR3SW4wLmV5SmhkV1FpT2lKa2FXUTZhMlY1T25vMlRXdHJhVU5LWWtWVlVtRk5TMGh5ZEd0RloySnBWVUZqZUhBemMyZDBVVEZOWlZkd2EyZGpiVkZoVm1WWE5pSXNJbUYwZENJNlczc2lkMjVtY3lJNkltUmxiVzkxYzJWeUxtWnBjM05wYjI0dWJtRnRaUzl3ZFdKc2FXTXZibTkwWlhNdklpd2lZMkZ3SWpvaVQxWkZVbGRTU1ZSRkluMWRMQ0psZUhBaU9qa3lOVFk1TXprMU1EVXNJbWx6Y3lJNkltUnBaRHByWlhrNmVqWk5hMmhpWVRjMlduTnJWMnRGUjBacU5tWlVUV0owVkU1WWRuTkJORE0xZDFSNWJtVXhXWFpvUXpoclJISTNJaXdpYm1KbUlqb3hOak01TmpBNE9EYzRMQ0p3Y21ZaU9sdGRmUS50NnhWLXZ3ZjBNbm0yTmt3aXl4X2stRFVQVWJ1LThOU1dyUmc1U01rQmY3TWQ5dGZhZ2JTZkFzTS1iRDJCcUdxYUZ6TXRULUFtbzZwcE85cHhaZ0JDUSJdfQ.GzBKFMHthcqWNJZgiFCjS3zYsOT_ygwdacfxZl_LB0yGqfq_90Eb6Y7t33UFcxXi8k5mMjKV3_cjiGilMYwEAw'
+    showUcan({ target: { value: encodedUcan } })
   }
 
-  const showNextProof = () => {
-    if (decodedUcan?.payload.prf.length > 0) {
-      encodedUcan = decodedUcan.payload.prf[0]
-      decode({ target: { value: encodedUcan } })
-    }
+  const showProof = (event: CustomEvent) => {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-call
+    proofTree = event.detail.node
+    encodedUcan = proofTree.token
+    decodedUcan = ucan.decode(encodedUcan)
   }
 
   $: {
@@ -117,7 +129,7 @@
       <Row padding>
         <Column>
           <div style="padding-bottom: 5px">Paste an encoded UCAN</div>
-          <TextArea bind:value={encodedUcan} rows={14} on:input={decode} />
+          <TextArea bind:value={encodedUcan} rows={14} on:input={showUcan} />
         </Column>
       </Row>
       {#if encodedUcan === ''}
@@ -129,13 +141,6 @@
                 Show Invalid Example
               </Button>
             </ButtonSet>
-          </Column>
-        </Row>
-      {/if}
-      {#if decodedUcan?.payload.prf.length > 0}
-        <Row>
-          <Column>
-            <Button on:click={showNextProof}>Show Next Proof</Button>
           </Column>
         </Row>
       {/if}
@@ -173,6 +178,14 @@
     </Column>
   </div>
 </Row>
+
+{#if proofTree !== null && encodedUcan !== ''}
+  <Row>
+    <Column>
+      <Proof bind:proofTree on:selectproof={showProof} />
+    </Column>
+  </Row>
+{/if}
 
 {#if encodedUcan !== ''}
   {#if decodedUcan === null}


### PR DESCRIPTION
## Summary

This PR implements the following **features**

* [x] Add proof explorer
* [x] Update examples

The proof explorer lets users inspect any proofs that delegate to a UCAN.

<img width="587" alt="explorer-preview" src="https://user-images.githubusercontent.com/7957636/146280643-78347eb3-7b11-44b4-886c-95d5b3bca1d9.png">

The explorer shows the selected UCAN, delegates, and proofs. Each node also has an absolute label to make it easier to track them.

Tooltips show issuer, audience, and whether or not the UCAN is valid. 

A yellow triangle indicates UCANs that are invalid. The triangle is faded out when the UCAN cannot be decoded.

## Closing issues

Closes #7 