### PR TITLE
Fix encoded textarea resizing

### DIFF
--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -13,8 +13,7 @@
     StructuredListRow,
     StructuredListCell,
     StructuredListBody,
-    TextArea,
-    UnorderedList,
+    UnorderedList
   } from 'carbon-components-svelte'
   import { truncate } from 'carbon-components-svelte/actions'
   import { onMount } from 'svelte'
@@ -37,7 +36,7 @@
   let validation: Validation | null = null
   let proofTree: ProofTree = null
   let isMobileDevice: boolean
-  
+
   // It's pretty useful to expose UCAN as a constant in the window,
   // so developers can just open up the DevTools on the page and play with the library
   window['UCAN'] = ucans
@@ -125,29 +124,17 @@
 <Row>
   <div class="encode-decode-container">
     <Column>
-      <Row>
-        <Column>
-          <h3>Encoded</h3>
-        </Column>
-      </Row>
-      <Row padding>
-        <Column>
-          <div style="padding-bottom: 5px">Paste an encoded UCAN</div>
-          <TextArea bind:value={encodedUcan} rows={14} on:input={showUcan} />
-        </Column>
-      </Row>
-      {#if encodedUcan === ''}
-        <Row>
-          <Column>
-            <ButtonSet>
-              <Button on:click={showExample}>Show Example</Button>
-              <Button kind="secondary" on:click={showInvalidExample}>
-                Show Invalid Example
-              </Button>
-            </ButtonSet>
-          </Column>
-        </Row>
-      {/if}
+      <div class="encode-section">
+        <h3>Encoded</h3>
+        <div class="encode-container">
+          <div>Paste an encoded UCAN</div>
+          <textarea
+            class="bx--text-area"
+            bind:value={encodedUcan}
+            on:input={showUcan}
+          />
+        </div>
+      </div>
     </Column>
     <Column>
       <Row>
@@ -183,7 +170,18 @@
   </div>
 </Row>
 
-{#if proofTree !== null && encodedUcan !== ''}
+{#if encodedUcan === ''}
+  <Row>
+    <Column>
+      <ButtonSet>
+        <Button on:click={showExample}>Show Example</Button>
+        <Button kind="secondary" on:click={showInvalidExample}>
+          Show Invalid Example
+        </Button>
+      </ButtonSet>
+    </Column>
+  </Row>
+{:else if proofTree !== null}
   <Row>
     <Column>
       <Proof bind:proofTree on:selectproof={showProof} />
@@ -343,6 +341,20 @@
     grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
     grid-gap: 1rem;
     width: 100%;
+  }
+
+  .encode-section {
+    display: grid;
+    grid-template-rows: 2rem minmax(250px, auto);
+    row-gap: 1rem;
+    height: 100%;
+    padding-bottom: 1rem;
+  }
+  
+  .encode-container {
+    display: grid;
+    grid-template-rows: 14px auto;
+    row-gap: 5px;
   }
 
   .validation-errors {


### PR DESCRIPTION
## Summary
<!-- Summary of the PR -->

This PR fixes the following **bugs**

* [x] Fixes #5
* [x] Move show example buttons into same row as proof explorer

The Encoded textarea did not resize after decoding and displaying a UCAN. The problem was that we set a static number of rows for the textarea. The TextArea component requires some value for rows, so the fix was to use a plain `<textarea>` with the Carbon `bx--text-area` styles and some CSS grid to set a minimum height and auto-sizing.

I also noticed the show example buttons were in a weird place in the markup, and moved them down to be with the proof explorer.

## Test plan (required)

![textarea-resize](https://user-images.githubusercontent.com/7957636/148599105-07310ab6-d258-408a-9bcb-d267affd05c4.gif)


## Closing issues

Closes #5 
