### PR TITLE
Upgrade `ts-ucan` version and tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 .eslintrc.cjs
 svelte.config.js
 tsnode-loader.js
+src/hooks.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "svelte-highlight": "^5.1.3",
-        "ucans": "https://github.com/ucan-wg/ts-ucan#3ea28d444fd5c917345859f72ee1d81615ef788f",
+        "ucans": "https://github.com/ucan-wg/ts-ucan#e10bdeca26e663df72e4266ccd9d47f8ce100665",
         "uint8arrays": "^3.0.0"
       },
       "devDependencies": {
@@ -4918,8 +4918,8 @@
     },
     "node_modules/ucans": {
       "version": "0.8.0",
-      "resolved": "git+ssh://git@github.com/ucan-wg/ts-ucan.git#3ea28d444fd5c917345859f72ee1d81615ef788f",
-      "integrity": "sha512-yJ4Xw7Lw41VYsKhuzoyx2m3NMfrIfyjurPrtQTW11Z+vo/dyZriEKVk/j9gMUvyXzLUb+vu0h07OFIfK0tV1Ng==",
+      "resolved": "git+ssh://git@github.com/ucan-wg/ts-ucan.git#e10bdeca26e663df72e4266ccd9d47f8ce100665",
+      "integrity": "sha512-TuMnChMFYkXaMY+/5PGMoS19yndclnUuuiy5Hy9dGHRlbRVOZrpaI9/6Z1R21xI4wkGRPU7WlIfKi/oOX9C6YQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "one-webcrypto": "^1.0.1",
@@ -8955,9 +8955,9 @@
       "dev": true
     },
     "ucans": {
-      "version": "git+ssh://git@github.com/ucan-wg/ts-ucan.git#3ea28d444fd5c917345859f72ee1d81615ef788f",
-      "integrity": "sha512-yJ4Xw7Lw41VYsKhuzoyx2m3NMfrIfyjurPrtQTW11Z+vo/dyZriEKVk/j9gMUvyXzLUb+vu0h07OFIfK0tV1Ng==",
-      "from": "ucans@https://github.com/ucan-wg/ts-ucan#3ea28d444fd5c917345859f72ee1d81615ef788f",
+      "version": "git+ssh://git@github.com/ucan-wg/ts-ucan.git#e10bdeca26e663df72e4266ccd9d47f8ce100665",
+      "integrity": "sha512-TuMnChMFYkXaMY+/5PGMoS19yndclnUuuiy5Hy9dGHRlbRVOZrpaI9/6Z1R21xI4wkGRPU7WlIfKi/oOX9C6YQ==",
+      "from": "ucans@https://github.com/ucan-wg/ts-ucan#e10bdeca26e663df72e4266ccd9d47f8ce100665",
       "requires": {
         "one-webcrypto": "^1.0.1",
         "tweetnacl": "^1.0.3",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "type": "module",
   "dependencies": {
-    "ucans": "https://github.com/ucan-wg/ts-ucan#3ea28d444fd5c917345859f72ee1d81615ef788f",
+    "ucans": "https://github.com/ucan-wg/ts-ucan#e10bdeca26e663df72e4266ccd9d47f8ce100665",
     "svelte-highlight": "^5.1.3",
     "uint8arrays": "^3.0.0"
   },

--- a/src/lib/ucan.test.ts
+++ b/src/lib/ucan.test.ts
@@ -26,12 +26,12 @@ test('validates a ucan', async t => {
     lifetimeInSeconds: 1000
   })
 
-  const result = await validate(token)
+  const { validation } = await validate(ucan.encode(token))
 
-  t.is(result.active, true)
-  t.is(result.valid, true)
-  t.is(result.validIssuer, true)
-  t.is(result.validProofs, true)
+  t.is(validation.active, true)
+  t.is(validation.valid, true)
+  t.is(validation.validIssuer, true)
+  t.is(validation.validProofs, true)
 })
 
 test('validates a delegated ucan', async t => {
@@ -60,12 +60,12 @@ test('validates a delegated ucan', async t => {
     proofs: [ucan.encode(rootToken)]
   })
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.active, true)
-  t.is(result.valid, true)
-  t.is(result.validIssuer, true)
-  t.is(result.validProofs, true)
+  t.is(validation.active, true)
+  t.is(validation.valid, true)
+  t.is(validation.validIssuer, true)
+  t.is(validation.validProofs, true)
 })
 
 
@@ -114,12 +114,12 @@ test('validates a delegated ucan with two proofs', async t => {
     ]
   })
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.active, true)
-  t.is(result.valid, true)
-  t.is(result.validIssuer, true)
-  t.is(result.validProofs, true)
+  t.is(validation.active, true)
+  t.is(validation.valid, true)
+  t.is(validation.validIssuer, true)
+  t.is(validation.validProofs, true)
 })
 
 
@@ -138,9 +138,9 @@ test('identifies a ucan that is not valid yet', async t => {
     expiration: 2637352774
   })
 
-  const result = await validate(token)
+  const { validation } = await validate(ucan.encode(token))
 
-  t.is(result.notValidYet, true)
+  t.is(validation.notValidYet, true)
 })
 
 test('identifies an expired ucan', async t => {
@@ -156,9 +156,9 @@ test('identifies an expired ucan', async t => {
     lifetimeInSeconds: 0
   })
 
-  const result = await validate(token)
+  const { validation } = await validate(ucan.encode(token))
 
-  t.is(result.active, false)
+  t.is(validation.active, false)
 })
 
 test('identifies an invalid signature', async t => {
@@ -177,9 +177,9 @@ test('identifies an invalid signature', async t => {
   // Invalid signature
   token.signature = 'PJf68hYl0_JaoMCTkNIavTwrxB98hRFoNh8jWH8rW7rQFmhge3Y4kbXnp0gLPGNBFZzQfgbdUHaS6xZrTfBdAg=='
 
-  const result = await validate(token)
+  const { validation } = await validate(ucan.encode(token))
 
-  t.is(result.valid, false)
+  t.is(validation.valid, false)
 })
 
 test('identifies a mismatched delegate', async t => {
@@ -209,9 +209,9 @@ test('identifies a mismatched delegate', async t => {
     proofs: [ucan.encode(rootToken)]
   })
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.validIssuer, false)
+  t.is(validation.validIssuer, false)
 })
 
 test('identifies when any proof has a mistmatched delegate', async t => {
@@ -260,9 +260,9 @@ test('identifies when any proof has a mistmatched delegate', async t => {
     ]
   })
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.validIssuer, false)
+  t.is(validation.validIssuer, false)
 })
 
 test('identifies an invalid proof', async t => {
@@ -294,9 +294,9 @@ test('identifies an invalid proof', async t => {
     proofs: [ucan.encode(rootToken)]
   })
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.validProofs, false)
+  t.is(validation.validProofs, false)
 })
 
 test('identifies when any proof is invalid', async t => {
@@ -347,9 +347,9 @@ test('identifies when any proof is invalid', async t => {
     ]
   })
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.validProofs, false)
+  t.is(validation.validProofs, false)
 })
 
 test('identifies multiple issues', async t => {
@@ -385,10 +385,10 @@ test('identifies multiple issues', async t => {
   // Invalid signature
   delegateToken.signature = 'PJf68hYl0_JaoMCTkNIavTwrxB98hRFoNh8jWH8rW7rQFmhge3Y4kbXnp0gLPGNBFZzQfgbdUHaS6xZrTfBdAg=='
 
-  const result = await validate(delegateToken)
+  const { validation } = await validate(ucan.encode(delegateToken))
 
-  t.is(result.active, false)
-  t.is(result.valid, false)
-  t.is(result.validIssuer, false)
-  t.is(result.validProofs, false)
+  t.is(validation.active, false)
+  t.is(validation.valid, false)
+  t.is(validation.validIssuer, false)
+  t.is(validation.validProofs, false)
 })


### PR DESCRIPTION
## Summary

This PR fixes/implements the following **bugs/features**

* [x] Upgrade to latest `ts-ucan` version
* [x] Update tests
* [x] Eslint ignore `src/hooks.ts`

The main goal is to upgrade to the latest `ts-ucan` so we can validate older UCAN versions. I also noticed we missed upgrading the tests in #14 (my fault, totally overlooked this in review 😅) and this PR updates them.

I also tacked on a adding `src/hooks.ts` to `.eslintignore`. Ultimately, we should probably address the Eslint errors in this file.

## Test plan (required)

Run the tests with `npm run test`. The should pass. ✅ ✅ ✅ 