### PR TITLE
Upgrade carbon components

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ With UCAN Check, you can:
 
 ## Try it
 
-UCAN Check is live at: https://ucancheck.fission.app/
+UCAN Check is live at: https://ucan.xyz
 
-# Setup
+## Setup
 
 Install dependencies.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "@typescript-eslint/eslint-plugin": "^4.33.0",
         "@typescript-eslint/parser": "^4.33.0",
         "ava": "^3.15.0",
-        "carbon-components-svelte": "^0.42.2",
+        "carbon-components-svelte": "^0.60.0",
+        "carbon-icons-svelte": "^10.44.4",
         "eslint": "^7.32.0",
         "eslint-config-prettier": "^8.1.0",
         "eslint-plugin-svelte3": "^3.2.1",
@@ -1045,12 +1046,11 @@
       }
     },
     "node_modules/carbon-components-svelte": {
-      "version": "0.42.3",
-      "resolved": "https://registry.npmjs.org/carbon-components-svelte/-/carbon-components-svelte-0.42.3.tgz",
-      "integrity": "sha512-1sYcF1Fc5xGvwLfuoS7MCZFZW+sz6rKunubvgaUj97clhJxK6r+j5aDjtgZWcCzEWWddJOuA/4a6NDCFZqSJAg==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/carbon-components-svelte/-/carbon-components-svelte-0.60.0.tgz",
+      "integrity": "sha512-2Ppr5wqiEQpU8NmD9SIsq1P2ci4zekt/0L4YWuCEDN5YwQlfas687jVsHrWjUz3OzyBTej8Wd521ftP7lsXXhQ==",
       "dev": true,
       "dependencies": {
-        "carbon-icons-svelte": "^10.36.0",
         "flatpickr": "4.6.9"
       }
     },
@@ -6401,12 +6401,11 @@
       "dev": true
     },
     "carbon-components-svelte": {
-      "version": "0.42.3",
-      "resolved": "https://registry.npmjs.org/carbon-components-svelte/-/carbon-components-svelte-0.42.3.tgz",
-      "integrity": "sha512-1sYcF1Fc5xGvwLfuoS7MCZFZW+sz6rKunubvgaUj97clhJxK6r+j5aDjtgZWcCzEWWddJOuA/4a6NDCFZqSJAg==",
+      "version": "0.60.0",
+      "resolved": "https://registry.npmjs.org/carbon-components-svelte/-/carbon-components-svelte-0.60.0.tgz",
+      "integrity": "sha512-2Ppr5wqiEQpU8NmD9SIsq1P2ci4zekt/0L4YWuCEDN5YwQlfas687jVsHrWjUz3OzyBTej8Wd521ftP7lsXXhQ==",
       "dev": true,
       "requires": {
-        "carbon-icons-svelte": "^10.36.0",
         "flatpickr": "4.6.9"
       }
     },

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "ava": "^3.15.0",
-    "carbon-components-svelte": "^0.42.2",
+    "carbon-components-svelte": "^0.60.0",
+    "carbon-icons-svelte": "^10.44.4",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.1.0",
     "eslint-plugin-svelte3": "^3.2.1",
@@ -39,8 +40,8 @@
   },
   "type": "module",
   "dependencies": {
-    "ucans": "https://github.com/ucan-wg/ts-ucan#e10bdeca26e663df72e4266ccd9d47f8ce100665",
     "svelte-highlight": "^5.1.3",
+    "ucans": "https://github.com/ucan-wg/ts-ucan#e10bdeca26e663df72e4266ccd9d47f8ce100665",
     "uint8arrays": "^3.0.0"
   },
   "ava": {


### PR DESCRIPTION
## Summary

This PR implements the following changes

* [x] Upgrade to latest `carbon-components-svelte`
* [x] Minor README updates
  * [x] Update site URL
  * [x] Decrease a heading size to match the others

This PR is mostly addressing a breaking change is Svelte that was taken care of by Carbon Components Svelte: https://github.com/carbon-design-system/carbon-components-svelte/pull/1088

Added a few minor README changes here as well.

## Test plan (required)

Run it. The weird spaces before the header, payload, and signature should be gone.