### PR TITLE
Convert docoutline to TypeScript

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -20,9 +20,7 @@
   import { route } from '$lib/nav_store'
 
   let setDevice = () => { return false }
-  // let buildDocOutline = (selector : string) => { return  ( selector.length === 0 ) || false }
   let isMobileDevice: boolean
-  // let deviceType: string
 
   // XXX TODO: investigate how to derive this object from sveltekits internals?
   let siteNavMap = [
@@ -41,12 +39,10 @@
         isMobileDevice = false
       }
 
-      // console.log(`isMobileDevice::${isMobileDevice}`)
       return isMobileDevice
     }
-    setDevice()
 
-    // console.log(`Pathname: ${$route.pathname}`)
+    setDevice()
   })
 </script>
 

--- a/src/components/OutlineHelper.svelte
+++ b/src/components/OutlineHelper.svelte
@@ -1,22 +1,17 @@
-<script>
-
+<script lang="ts">
 import { route } from '$lib/nav_store'
-import build from '$lib/docoutline'
+import { build } from '$lib/docoutline'
 import { onMount, tick } from 'svelte'
 
-onMount(() => {
-  // console.log(`in OutlineHelper.onMount() ${document.location.pathname}`)
-
+onMount(async () => {
   // set the route store to the current browser state
   route.set({
     pathname: document.location.pathname,
     hash: document.location.hash
-  });
+  })
 
-  (async function () {
-    await tick()
-    build('div.markdown-generated')
-  })()
+  await tick()
+  build('div.markdown-generated')
 })
 
 </script>

--- a/src/lib/docoutline.ts
+++ b/src/lib/docoutline.ts
@@ -1,39 +1,36 @@
-function createMenuEntry(element) {
-  let span = document.createElement('span')
+function createMenuEntry(element: Element): HTMLLIElement {
+  const span = document.createElement('span')
   span.textContent = element.textContent
   span.className = 'bx--side-nav__link-text'
 
-  let link = document.createElement('a')
+  const link = document.createElement('a')
   link.className = 'bx--side-nav__link'
   link.href = `#${element.id}`
   link.appendChild(span)
 
-  let item = document.createElement('li')
+  const item = document.createElement('li')
   item.className = 'bx--side-nav__menu-item'
   item.appendChild(link)
   return item
 }
 
-function formatId(content) {
+function formatId(content: string): string {
   return content.replace(/[\s]/g, '-').toLowerCase().trim()
 }
 
-function reset(selector) {
-  let _outlineElement = document.querySelector(selector);
-  // console.log(`Resetting ${_outlineElement}`)
-  _outlineElement.innerHTML = ""
+function reset(selector: string): void {
+  const _outlineElement = document.querySelector(selector)
+  _outlineElement.innerHTML = ''
 }
 
-function build(selector) {
-
-  let sel_sidemenu = '.bx--side-nav__menu'
-  let subMenu = document.querySelector(sel_sidemenu)
+function build(selector: string): boolean {
+  const sel_sidemenu = '.bx--side-nav__menu'
+  const subMenu = document.querySelector(sel_sidemenu)
 
   if (subMenu) {
     reset(sel_sidemenu)
-    let headers = []
+    const headers: Element[] = []
   
-    // let selector = 'div.markdown-generated'
     document.querySelectorAll(`${selector} > *`).forEach((el) => {
       if (el.tagName.toLowerCase().startsWith('h')) {
         el.id = formatId(el.textContent)
@@ -42,7 +39,7 @@ function build(selector) {
     })
 
     headers.forEach(item => {
-      let _el = createMenuEntry(item)
+      const _el = createMenuEntry(item)
       subMenu.appendChild(_el)
     })
   }
@@ -50,4 +47,4 @@ function build(selector) {
   return true
 }
 
-export default build
+export { build }

--- a/src/lib/nav_store.js
+++ b/src/lib/nav_store.js
@@ -1,8 +1,0 @@
-import { writable } from 'svelte/store'
-
-let route = writable({
-  hash: null, 
-  pathname: null
-})
-
-export { route }

--- a/src/lib/nav_store.ts
+++ b/src/lib/nav_store.ts
@@ -1,0 +1,9 @@
+import type { Writable } from 'svelte/store'
+import { writable } from 'svelte/store'
+
+const route: Writable<{ hash: string; pathname: string }> = writable({
+  hash: null,
+  pathname: null
+})
+
+export { route }

--- a/src/routes/about.md
+++ b/src/routes/about.md
@@ -1,11 +1,6 @@
 <script lang="ts">
-
-  import {
-    OutboundLink
-  } from 'carbon-components-svelte'
-
   import OutlineHelper from '$components/OutlineHelper.svelte'
-
+  import { OutboundLink } from 'carbon-components-svelte'
 </script>
 
 <OutlineHelper />

--- a/src/routes/community.md
+++ b/src/routes/community.md
@@ -1,9 +1,6 @@
 <script lang="ts">
-  import {
-    OutboundLink
-  } from 'carbon-components-svelte'
-
   import OutlineHelper from '$components/OutlineHelper.svelte'
+  import { OutboundLink } from 'carbon-components-svelte'
 </script>
 
 <OutlineHelper />

--- a/src/routes/index.md
+++ b/src/routes/index.md
@@ -1,12 +1,8 @@
 <script lang="ts">
-import {
-} from 'carbon-components-svelte'
-
-import OutlineHelper from '$components/OutlineHelper.svelte'
-import Highlight from "svelte-highlight"
-import typescript from "svelte-highlight/src/languages/typescript";
-import github from "svelte-highlight/src/styles/github";
-
+  import github from "svelte-highlight/src/styles/github";
+  import Highlight from "svelte-highlight"
+  import typescript from "svelte-highlight/src/languages/typescript";
+  import OutlineHelper from '$components/OutlineHelper.svelte'
 </script>
 
 <svelte:head>

--- a/src/routes/learn.md
+++ b/src/routes/learn.md
@@ -1,17 +1,12 @@
 <script lang="ts">
-  import { Highlight, HighlightAuto } from "svelte-highlight"
-  import typescript from "svelte-highlight/src/languages/typescript";
   import github from "svelte-highlight/src/styles/github";
+  import typescript from "svelte-highlight/src/languages/typescript";
+  import { Highlight, HighlightAuto } from "svelte-highlight"
+  import { OutboundLink } from 'carbon-components-svelte'
+
   import OutlineHelper from '$components/OutlineHelper.svelte'
-  import { route } from '$lib/nav_store'
   import { onMount } from 'svelte'
-
-  import {
-    OutboundLink
-  } from 'carbon-components-svelte'
-
-  onMount(() => {
-  })
+  import { route } from '$lib/nav_store'
 
   const yarn_install = `yarn add ucans`;
   const npm_install = `npm install --save`;
@@ -82,5 +77,6 @@ Typescript:
  If you are using ucans in your work and have ideas for improvement, please consider adding any ideas for improvement to the UCAN Improvement Proposal repository: <OutboundLink href="https://github.com/ucan-wg/UIPs">github.com/ucan-wg/UIPs</OutboundLink>
 
 </div>
+
 <style>
 </style>


### PR DESCRIPTION
## Summary

This PR implements the following

* [x] Convert `docoutline.js` module to TypeScript
* [x] Convert `nav_store.js` module to TypeScript
* [x] Convert `onMount` in `OutlineHeader` to an async function
* [x] Re-organize imports in routes

## Test plan (required)

The documentation outlines should render as they did before.