### PR TITLE
fixes #29

### DIFF
--- a/src/routes/__layout.svelte
+++ b/src/routes/__layout.svelte
@@ -113,4 +113,11 @@
   font-weight: bold;
 }
 
+:global(:target::before) {
+  content: "";
+  display: block;
+  height: 60px; /* fixed header height*/
+  margin: -60px 0 0; /* negative fixed header height */
+}
+
 </style>


### PR DESCRIPTION
This seems to fix issue #29 ! Sourced from [Stackoverflow](https://stackoverflow.com/questions/4086107/fixed-page-header-overlaps-in-page-anchors/28824157#28824157)