### PR TITLE
Add link to ucan.storage site

### DIFF
--- a/src/routes/community.md
+++ b/src/routes/community.md
@@ -12,9 +12,11 @@
 * <OutboundLink  href="https://fission.codes/discord">Join the Fission Discord server</OutboundLink>
 * <OutboundLink  href="https://talk.fission.codes/tag/ucan">Fission Community Forum</OutboundLink>
 
-## Projects
+## Projects that use UCAN
 
-* <OutboundLink  href="https://github.com/nftstorage/ucan.storage">ucan.storage</OutboundLink>
+* <OutboundLink  href="https://github.com/nftstorage/ucan.storage">ucan.storage</OutboundLink>. 
+A UCAN implementation for storage on <OutboundLink href="https://web3.storage/">web3.storage</OutboundLink>
+and <OutboundLink href="https://nft.storage/">nft.storage</OutboundLink>.
 
 </div>
 

--- a/src/routes/community.md
+++ b/src/routes/community.md
@@ -12,6 +12,10 @@
 * <OutboundLink  href="https://fission.codes/discord">Join the Fission Discord server</OutboundLink>
 * <OutboundLink  href="https://talk.fission.codes/tag/ucan">Fission Community Forum</OutboundLink>
 
+## Projects
+
+* <OutboundLink  href="https://github.com/nftstorage/ucan.storage">ucan.storage</OutboundLink>
+
 </div>
 
 <style>


### PR DESCRIPTION
This PR adds a link to the `ucan-storage` project in the community page.