### PR TITLE
Add Fission projects to community page

### DIFF
--- a/src/routes/community.md
+++ b/src/routes/community.md
@@ -17,6 +17,7 @@
 * <OutboundLink  href="https://github.com/nftstorage/ucan.storage">ucan.storage</OutboundLink> is a UCAN implementation for storage on <OutboundLink href="https://web3.storage/">web3.storage</OutboundLink>
 and <OutboundLink href="https://nft.storage/">nft.storage</OutboundLink>.
 * <OutboundLink  href="https://subconscious.substack.com/">Subconscious</OutboundLink> is a distributed note taking tool that <OutboundLink href="https://subconscious.substack.com/p/layered-protocols">uses UCAN as part of its layered protocol design</OutboundLink>. They are also the authors of the <OutboundLink  href="https://github.com/cdata/rs-ucan">Rust UCAN library rs-ucan</OutboundLink>.
+* <OutboundLink  href="https://fission.codes/">Fission</OutboundLink> uses UCAN in the <OutboundLink href="https://github.com/fission-suite/webnative">Webnative SDK</OutboundLink> and in the <OutboundLink href="https://github.com/fission-suite/fission">Fission Server and CLI</OutboundLink>
 
 </div>
 


### PR DESCRIPTION
This PR adds the Fission Webnative SDK and the Fission Server/CLI to the community page as projects that use UCANs.