### PR TITLE
fix: svelte config for static publish

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -25,10 +25,10 @@
   // XXX TODO: investigate how to derive this object from sveltekits internals?
   let siteNavMap = [
     { href: '/', label: 'Introduction' },
-    { href: '/validator', label: 'Validator' },
-    { href: '/learn', label: 'Learn' },
-    { href: '/community', label: 'Community' },
-    { href: '/about', label: 'About' }
+    { href: '/validator/', label: 'Validator' },
+    { href: '/learn/', label: 'Learn' },
+    { href: '/community/', label: 'Community' },
+    { href: '/about/', label: 'About' }
   ]
 
   onMount(() => {
@@ -72,7 +72,7 @@
   </HeaderUtilities>
 </Header>
 
-{#if $route.pathname === '/validator'}   
+{#if $route.pathname === '/validator/'}   
   {#if isMobileDevice}
     <SideNav bind:isOpen={isSideNavOpen}>  
       <SideNavItems>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -25,6 +25,7 @@ const config = {
       assets: 'build',
       fallback: null
     }),
+    trailingSlash: 'always',
     vite: {
       optimizeDeps: {
         include: ["highlight.js/lib/core"], 


### PR DESCRIPTION
Svelte was rendering pages (e.g. about) as `about.html` rather than `about/index.html` which meant deep linking would fail.

This should be resolved now: https://ancient-angular-maroon-shark.fission.app/about/

Fixes #39