### PR TITLE
Add UCAN version label and link to spec

### DIFF
--- a/src/components/Header.svelte
+++ b/src/components/Header.svelte
@@ -19,7 +19,9 @@
 
   import { route } from '$lib/nav_store'
 
-  let setDevice = () => { return false }
+  let setDevice = () => {
+    return false
+  }
   let isMobileDevice: boolean
 
   // XXX TODO: investigate how to derive this object from sveltekits internals?
@@ -28,6 +30,7 @@
     { href: '/validator/', label: 'Validator' },
     { href: '/learn/', label: 'Learn' },
     { href: '/community/', label: 'Community' },
+    { href: 'https://github.com/ucan-wg/spec', label: 'Spec' },
     { href: '/about/', label: 'About' }
   ]
 
@@ -46,19 +49,21 @@
   })
 </script>
 
-<svelte:window
-  on:resize={setDevice}
-/>
+<svelte:window on:resize={setDevice} />
 
-<Header company="UCAN" platformName="Distributed Auth" href="/" bind:isSideNavOpen>
+<Header
+  company="UCAN"
+  platformName="Distributed Auth"
+  href="/"
+  bind:isSideNavOpen
+>
   <div slot="skip-to-content">
     <SkipToContent />
   </div>
 
   <HeaderNav>
-
     {#each siteNavMap as link}
-      <HeaderNavItem href="{link.href}" text="{link.label}" />
+      <HeaderNavItem href={link.href} text={link.label} />
     {/each}
   </HeaderNav>
 
@@ -72,26 +77,27 @@
   </HeaderUtilities>
 </Header>
 
-{#if $route.pathname === '/validator/'}   
+{#if $route.pathname === '/validator/'}
   {#if isMobileDevice}
-    <SideNav bind:isOpen={isSideNavOpen}>  
+    <SideNav bind:isOpen={isSideNavOpen}>
       <SideNavItems>
         {#each siteNavMap as link}
-          <SideNavLink href="{link.href}" text="{link.label}" />
+          <SideNavLink href={link.href} text={link.label} />
         {/each}
       </SideNavItems>
     </SideNav>
   {/if}
-{:else} // we are not on the validator tool page
+{:else}
+  // we are not on the validator tool page
   <SideNav bind:isOpen={isSideNavOpen}>
     <SideNavItems>
       {#if isMobileDevice}
         {#each siteNavMap as link}
-          <SideNavLink href="{link.href}" text="{link.label}" />
+          <SideNavLink href={link.href} text={link.label} />
         {/each}
         <SideNavDivider />
       {/if}
-      <SideNavMenu text="On This Page" expanded={true}></SideNavMenu>
+      <SideNavMenu text="On This Page" expanded={true} />
     </SideNavItems>
   </SideNav>
 {/if}

--- a/src/routes/validator.svelte
+++ b/src/routes/validator.svelte
@@ -13,6 +13,7 @@
     StructuredListRow,
     StructuredListCell,
     StructuredListBody,
+    Tag,
     UnorderedList
   } from 'carbon-components-svelte'
   import { truncate } from 'carbon-components-svelte/actions'
@@ -69,13 +70,17 @@
   const showExample = () => {
     encodedUcan =
       'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWtmUWhMSEJTRk11UjdiUVhUUWVxZTVrWVVXNTFIcGZaZWF5bWd5MXprUDJqTSIsImF0dCI6W3sid2l0aCI6eyJzY2hlbWUiOiJ3bmZzIiwiaGllclBhcnQiOiIvL2RlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyJ9LCJjYW4iOnsibmFtZXNwYWNlIjoid25mcyIsInNlZ21lbnRzIjpbIk9WRVJXUklURSJdfX0seyJ3aXRoIjp7InNjaGVtZSI6InduZnMiLCJoaWVyUGFydCI6Ii8vZGVtb3VzZXIuZmlzc2lvbi5uYW1lL3B1YmxpYy9ub3Rlcy8ifSwiY2FuIjp7Im5hbWVzcGFjZSI6InduZnMiLCJzZWdtZW50cyI6WyJPVkVSV1JJVEUiXX19XSwiZXhwIjo5MjU2OTM5NTA1LCJpc3MiOiJkaWQ6a2V5Ono2TWtyNWFlZmluMUR6akc3TUJKM25zRkNzbnZIS0V2VGIyQzRZQUp3Ynh0MWpGUyIsInByZiI6WyJleUpoYkdjaU9pSkZaRVJUUVNJc0luUjVjQ0k2SWtwWFZDSXNJblZqZGlJNklqQXVPQzR4SW4wLmV5SmhkV1FpT2lKa2FXUTZhMlY1T25vMlRXdHlOV0ZsWm1sdU1VUjZha2MzVFVKS00yNXpSa056Ym5aSVMwVjJWR0l5UXpSWlFVcDNZbmgwTVdwR1V5SXNJbUYwZENJNlczc2lkMmwwYUNJNmV5SnpZMmhsYldVaU9pSjNibVp6SWl3aWFHbGxjbEJoY25RaU9pSXZMMlJsYlc5MWMyVnlMbVpwYzNOcGIyNHVibUZ0WlM5d2RXSnNhV012Y0dodmRHOXpMeUo5TENKallXNGlPbnNpYm1GdFpYTndZV05sSWpvaWQyNW1jeUlzSW5ObFoyMWxiblJ6SWpwYklrOVdSVkpYVWtsVVJTSmRmWDFkTENKbGVIQWlPamt5TlRZNU16azFNRFVzSW1semN5STZJbVJwWkRwclpYazZlalpOYTJ0WGIzRTJVek4wY1ZKWGNXdFNibmxOWkZobWNuTTFORGxGWm5VMmNVTjFOSFZxUkdaTlkycEdVRXBTSWl3aWNISm1JanBiWFgwLlNqS2FIR18yQ2UwcGp1TkY1T0QtYjZqb04xU0lKTXBqS2pqbDRKRTYxX3VwT3J0dktvRFFTeFo3V2VZVkFJQVREbDhFbWNPS2o5T3FPU3cwVmc4VkNBIiwiZXlKaGJHY2lPaUpGWkVSVFFTSXNJblI1Y0NJNklrcFhWQ0lzSW5WamRpSTZJakF1T0M0eEluMC5leUpoZFdRaU9pSmthV1E2YTJWNU9ubzJUV3R5TldGbFptbHVNVVI2YWtjM1RVSktNMjV6UmtOemJuWklTMFYyVkdJeVF6UlpRVXAzWW5oME1XcEdVeUlzSW1GMGRDSTZXM3NpZDJsMGFDSTZleUp6WTJobGJXVWlPaUozYm1aeklpd2lhR2xsY2xCaGNuUWlPaUl2TDJSbGJXOTFjMlZ5TG1acGMzTnBiMjR1Ym1GdFpTOXdkV0pzYVdNdmNHaHZkRzl6THlKOUxDSmpZVzRpT25zaWJtRnRaWE53WVdObElqb2lkMjVtY3lJc0luTmxaMjFsYm5SeklqcGJJazlXUlZKWFVrbFVSU0pkZlgxZExDSmxlSEFpT2preU5UWTVNemsxTURVc0ltbHpjeUk2SW1ScFpEcHJaWGs2ZWpaTmEydFhiM0UyVXpOMGNWSlhjV3RTYm5sTlpGaG1jbk0xTkRsRlpuVTJjVU4xTkhWcVJHWk5ZMnBHVUVwU0lpd2ljSEptSWpwYlhYMC5TakthSEdfMkNlMHBqdU5GNU9ELWI2am9OMVNJSk1waktqamw0SkU2MV91cE9ydHZLb0RRU3haN1dlWVZBSUFURGw4RW1jT0tqOU9xT1N3MFZnOFZDQSJdfQ.Ab-xfYRoqYEHuo-252MKXDSiOZkLD-h1gHt8gKBP0AVdJZ6Jruv49TLZOvgWy9QkCpiwKUeGVbHodKcVx-azCQ'
-    showUcan({ target: { value: encodedUcan } }).then().catch(err => console.log(err))
+    showUcan({ target: { value: encodedUcan } })
+      .then()
+      .catch(err => console.log(err))
   }
 
   const showInvalidExample = () => {
     encodedUcan =
       'eyJhbGciOiJFZERTQSIsInR5cCI6IkpXVCIsInVjdiI6IjAuOC4xIn0.eyJhdWQiOiJkaWQ6a2V5Ono2TWt1ZTdzYWdudEhWZEFoTWN5V0tyMkQ1VE12VUVXVW5EN1d0Z05aZFRGcDdHNSIsImF0dCI6W3sid2l0aCI6eyJzY2hlbWUiOiJ3bmZzIiwiaGllclBhcnQiOiIvL2RlbW91c2VyLmZpc3Npb24ubmFtZS9wdWJsaWMvcGhvdG9zLyJ9LCJjYW4iOnsibmFtZXNwYWNlIjoid25mcyIsInNlZ21lbnRzIjpbIk9WRVJXUklURSJdfX1dLCJleHAiOjkyNTY5Mzk1MDUsImlzcyI6ImRpZDprZXk6ejZNa25lS01nZHpSeDJDdzZIMnJEcFpWdTU4VUY3THNwZzg4aVc3WmdURkQ5aTh4IiwicHJmIjpbImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJa3BYVkNJc0luVmpkaUk2SWpBdU9DNHhJbjAuZXlKaGRXUWlPaUprYVdRNmEyVjVPbm8yVFd0MVpUZHpZV2R1ZEVoV1pFRm9UV041VjB0eU1rUTFWRTEyVlVWWFZXNUVOMWQwWjA1YVpGUkdjRGRITlNJc0ltRjBkQ0k2VzNzaWQybDBhQ0k2ZXlKelkyaGxiV1VpT2lKM2JtWnpJaXdpYUdsbGNsQmhjblFpT2lJdkwyUmxiVzkxYzJWeUxtWnBjM05wYjI0dWJtRnRaUzl3ZFdKc2FXTXZjR2h2ZEc5ekx5SjlMQ0pqWVc0aU9uc2libUZ0WlhOd1lXTmxJam9pZDI1bWN5SXNJbk5sWjIxbGJuUnpJanBiSWs5V1JWSlhVa2xVUlNKZGZYMWRMQ0psZUhBaU9qa3lOVFk1TXprMU1EVXNJbWx6Y3lJNkltUnBaRHByWlhrNmVqWk5hM0Z3Y25Ga05sUkJhRFoxV0ZNemNVc3hPVWQ0Y1hSNFNtUlRlbGx6UlZJMWNVdDNWa0kxZDJGQmJtbDNJaXdpY0hKbUlqcGJYWDAuUEpmNjhoWWwwX0phb01DVGtOSWF2VHdyeEI5OGhSRm9OaDhqV0g4clc3clFGbWhnZTNZNGtiWG5wMGdMUEdOQkZaelFmZ2JkVUhhUzZ4WnJUZkJkQWc9PSIsImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJa3BYVkNJc0luVmpkaUk2SWpBdU9DNHhJbjAuZXlKaGRXUWlPaUprYVdRNmEyVjVPbm8yVFd0MmNVNTJRelpUZFdNeWFuRnljekZFYTNoSVVWVXhTbTlWWFpsVW5FNFkyTm5SV1EwUm1wcVZuWmFJaXdpYm1KbUlqb3hOak01TmpBNE56a3pMQ0p3Y21ZaU9sdGRmUS55Vll3OGN0U0RHYjJseGVTTDkwN09tbk1ZVU5XeUNiOVRlRmdHbGdOYjA5dHZoVEFkTTQ2ekpJTG1wLS1ja3RzeUhaZlRuQi1VVVFFMlFOWlg1WnVBQSIsImV5SmhiR2NpT2lKRlpFUlRRU0lzSW5SNWNDSTZJa3BYVkNJc0luVmpkaUk2SWpBdU9DNHhJbjAuZXlKaGRXUWlPaUprYVdRNmEyVjVPbm8yVFd0dVpVdE5aMlI2VW5neVEzYzJTREp5UkhCYVZuVTFPRlZHTjB4emNHYzRPR2xYTjFwblZFWkVPV2s0ZUNJc0ltRjBkQ0k2VzNzaWQybDBhQ0k2ZXlKelkyaGxiV1VpT2lKM2JtWnpJaXdpYUdsbGNsQmhjblFpT2lJdkwyUmxiVzkxYzJWeUxtWnBjM05wYjI0dWJtRnRaUzl3ZFdKc2FXTXZibTkwWlhNdkluMHNJbU5oYmlJNmV5SnVZVzFsYzNCaFkyVWlPaUozYm1aeklpd2ljMlZuYldWdWRITWlPbHNpVDFaRlVsZFNTVlJGSWwxOWZWMHNJbVY0Y0NJNk9USTFOamt6T1RVd05Td2lhWE56SWpvaVpHbGtPbXRsZVRwNk5rMXJjWEJ5Y1dRMlZFRm9OblZZVXpOeFN6RTVSM2h4ZEhoS1pGTjZXWE5GVWpWeFMzZFdRalYzWVVGdWFYY2lMQ0p3Y21ZaU9sdGRmUS5hdzJEQmh5T0hiN0MzTXJadURJa3N1SUZadjM2Z0VyaHFwaHMxemh6TEwxZjhHb0QwZU02bGJMZ1dGaEFJLVBPTGZBR204V2JGcFdXOW1IT2VESThEQSJdfQ.BbgQLCU-0QiTBOctnALSN5Ale-k4KXc4NEwn5RQ9gqpzVQUcGNg2kSUJblxEMGl0hDntLzreh0LGqcwqN9QpAw'
-    showUcan({ target: { value: encodedUcan } }).then().catch(err => console.log(err))
+    showUcan({ target: { value: encodedUcan } })
+      .then()
+      .catch(err => console.log(err))
   }
 
   const showProof = async (event: CustomEvent) => {
@@ -119,7 +124,16 @@
       <div class="encode-section">
         <h3>Encoded</h3>
         <div class="encode-container">
-          <div>Paste an encoded UCAN</div>
+          <div class="encode-label">
+            <span> Paste an encoded UCAN </span>
+            <a
+              class="version-support-label"
+              href="https://github.com/ucan-wg/spec/blob/a411500d005e874f3cfa4010c82dc66d40a313f2/README.md"
+              target="_blank"
+            >
+              <Tag interactive type="blue" size="sm">Up to UCAN 0.8.1</Tag>
+            </a>
+          </div>
           <textarea
             class="bx--text-area"
             bind:value={encodedUcan}
@@ -342,11 +356,23 @@
     height: 100%;
     padding-bottom: 1rem;
   }
-  
+
   .encode-container {
     display: grid;
     grid-template-rows: 14px auto;
-    row-gap: 5px;
+    row-gap: 10px;
+  }
+
+  .encode-label {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    align-items: center;
+  }
+
+  .version-support-label {
+    display: grid;
+    justify-items: end;
+    text-decoration: none;
   }
 
   .validation-errors {


### PR DESCRIPTION
This PR implements the following features:

- [x] Adds a label to the validator to indicate the latest supported version
- [x] Adds a direct link to the spec in the header

The spec will sometimes be ahead of implementations, including `ts-ucan` which we use here in the validator. The label gives an indication of which UCAN versions are supported by the validator.

<img width="686" alt="ucan-support-label" src="https://user-images.githubusercontent.com/7957636/188962324-28bd86d3-a9bd-4d56-8e53-8fedfa289393.png">

The label is clickable and will open a new tab with the spec at UCAN 0.8.1.

We've received feedback that the link to the specification is difficult to find, so this PR adds a link in the header.

<img width="1176" alt="spec-link" src="https://user-images.githubusercontent.com/7957636/188963192-60f6b32b-7fa0-4816-8b38-14782a748dc9.png">



