### PR TITLE
Add link to Fission

### DIFF
--- a/src/routes/about.md
+++ b/src/routes/about.md
@@ -9,7 +9,7 @@
 
 # About
 
-UCANs were originally created by [Brooklyn Zelenka](https://twitter.com/expede) in 2019 as part of her work in creating a set of distributed data storage, communications and distributed computing protocols at Fission Internet Corp.
+UCANs were originally created by [Brooklyn Zelenka](https://twitter.com/expede) in 2019 as part of her work in creating a set of distributed data storage, communications and distributed computing protocols at [Fission Internet Corp](https://fission.codes).
 
 ## Links
 


### PR DESCRIPTION
"Fission Internet Corp" is difficult to Google. Let's just link to it.